### PR TITLE
Cleaner docker terminal output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,8 @@ RUN curl -O https://php-school.github.io/workshop-manager/workshop-manager.phar 
     && chmod +x /usr/local/bin/workshop-manager \
     && workshop-manager verify
 
+RUN echo PS1=\"\\[\\e[35m\\]$ \\e[0m\\]\" >> ~/.bashrc
+RUN echo TERM=xterm >> ~/.bashrc
+
 WORKDIR /phpschool
 CMD ["bash"]


### PR DESCRIPTION
Replace PS1 so that it just outputs a pink `$ ` as the prompt 👌 
Also make sure that term is set to xterm for full colour support

For some reason can't do this through docker `ENV` command so added to ~/.bashrc seemed best