### PR TITLE
Only decrypt secrets on master branch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     env: SYMFONY_VERSION='3.1.*'
 
 before_install:
-  - openssl aes-256-cbc -K $encrypted_d3e7229d64cc_key -iv $encrypted_d3e7229d64cc_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d
+  - if [[ $EXECUTE_DEPLOYMENT == 'true' && $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then openssl aes-256-cbc -K $encrypted_d3e7229d64cc_key -iv $encrypted_d3e7229d64cc_iv -in .travis/secrets.tar.enc -out .travis/secrets.tar -d ; fi
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/console=$SYMFONY_VERSION; fi
 


### PR DESCRIPTION
It seems when people send PR's the decryption fails on the travis builds because external contributors do not have access to secrets.